### PR TITLE
chore: set package.json version to 1.4.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,22 @@ There are no parameters in this module that are exclusive to KOMODO-X. Everythin
 
 ## Changelog
 
+### v1.4.8
+
+Maintenance release addressing Bitfocus code review feedback.
+
+**Upgrade script:** Existing buttons using old action IDs (`start_record`, `stop_record`, `toggle_record`) are automatically migrated to the current names on load.
+
+**Bug fixes:**
+- WebSocket errors now correctly report `ConnectionFailure` status
+- Stagger timers properly cleaned up on destroy/disconnect
+- `Set ISO` and `Set Sensor Frame Rate` now ignore invalid (NaN) input
+- LUT subscribe parameter IDs corrected — `lut_sdi1_enabled` / `lut_sdi2_enabled` variables now populate correctly
+
+**Code structure:** Split into `src/` modules per Bitfocus standards (`actions.js`, `feedbacks.js`, `variables.js`, `upgrades.js`).
+
+---
+
 ### v1.4.6
 
 **Connection state variable**

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -6,7 +6,23 @@ Type in the IP address of the RED camera. Works with all DSMC3 cameras (V-RAPTOR
 
 ---
 
-### v1.4.6 — What's New
+### v1.4.8 — What's New
+
+Maintenance release addressing Bitfocus code review feedback. No new features — all changes are internal.
+
+**Upgrade script:** Existing buttons using the old action IDs (`start_record`, `stop_record`, `toggle_record`) are automatically migrated to the current names (`start_recording`, `stop_recording`, `toggle_recording`) when the module loads. No manual button updates needed.
+
+**Bug fixes:**
+- WebSocket errors now correctly update the connection status indicator
+- Stagger timers are now properly cleaned up when the module is destroyed or the connection drops
+- `Set ISO` and `Set Sensor Frame Rate` actions now correctly ignore invalid input instead of sending garbage values to the camera
+- LUT subscribe parameter IDs corrected (`ENABLE_CAMERA_LUT_SDI_1/2`) — LUT state variables were not populating on some firmware versions
+
+**Code structure:** Module split into `src/` files (`actions.js`, `feedbacks.js`, `variables.js`, `upgrades.js`) per Bitfocus module standards.
+
+---
+
+### v1.4.6
 
 This release expands parameter coverage, improves reliability, and significantly reduces CPU usage.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "companion-module-red-rcp2",
-    "version": "0.0.0",
+    "version": "1.4.8",
     "main": "src/main.js",
     "type": "module",
     "license": "MIT",


### PR DESCRIPTION
Sets `package.json` version to `1.4.8`. The previous PR (#14) merged before this was corrected from `0.0.0`.

Required for the Bitfocus build system to match the git tag version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)