### PR TITLE
fix: correct SHUTDOWN_POWER_OFF value to 2

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -285,7 +285,7 @@ export function getActionDefinitions(self) {
 			options: [{ type: 'checkbox', label: 'Confirm Shutdown (must be checked to proceed)', id: 'confirm', default: false }],
 			callback: async (action) => {
 				if (action.options.confirm) {
-					self.send({ type: 'rcp_set', id: 'SHUTDOWN', value: 1 })
+					self.send({ type: 'rcp_set', id: 'SHUTDOWN', value: 2 })
 					self.log('info', 'Shutdown command sent to camera')
 				} else {
 					self.log('warn', 'Shutdown not confirmed — checkbox must be enabled')


### PR DESCRIPTION
Per Page 339 of the Komodo-X RCP2 API documentation (and confirmed with other models documentation) Shutdown of Value 1 restarts the RED Camera, while Value of 2, Shuts down and stays shutdown. Current module restarts the camera based on using it on Komodo-X

https://www.red.com/download/rcp2-documentation

Relevant section from documentation: 
RCP_PARAM_SHUTDOWN
Type: Action (with status)
Shutdown
Request a shutdown of the camera. For request type SHUTDOWN_REQUEST, the camera will shut down and restart. For request type SHUTDOWN_POWER_OFF, the camera will shut down and remain off until the power switch is toggled to off and then on.

TYPES
"SHUTDOWN_REQUEST" : {
"SHUTDOWN_REQUEST" : 1,
"SHUTDOWN_POWER_OFF" : 2
}