### PR TITLE
Added Restart Camera Action

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -292,6 +292,11 @@ export function getActionDefinitions(self) {
 				}
 			},
 		},
+		restart_camera: {
+			name: 'Restart Camera',
+			options: [],
+			callback: () => self.send({ type: 'rcp_set', id: 'SHUTDOWN', value: 1 }),
+		},
 		send_command: {
 			name: 'Send Generic Command',
 			options: [{ type: 'textinput', label: 'Raw JSON Data', id: 'data', default: '{ "type": "rcp_set", "id": "ISO", "val": 800 }', useVariables: true }],


### PR DESCRIPTION
Added option for Restarting Camera using the Shutdown Value of 1 based on the documentation. To be combined with Pull Request #18 that adjusts the current shutdown trigger to be a true shutdown and stay down, while this would act as how the current shutdown action does. 

https://www.red.com/download/rcp2-documentation

Relevant section from documentation:
RCP_PARAM_SHUTDOWN
Type: Action (with status)
Shutdown
Request a shutdown of the camera. For request type SHUTDOWN_REQUEST, the camera will shut down and restart. For request type SHUTDOWN_POWER_OFF, the camera will shut down and remain off until the power switch is toggled to off and then on.

TYPES
"SHUTDOWN_REQUEST" : {
"SHUTDOWN_REQUEST" : 1,
"SHUTDOWN_POWER_OFF" : 2
}